### PR TITLE
Add always run scripts

### DIFF
--- a/docs/data-sources/vm.md
+++ b/docs/data-sources/vm.md
@@ -44,6 +44,7 @@ data "parallels-desktop_vm" "example" {
 - `filter` (Block, Optional) Filter block, this is used to filter data sources (see [below for nested schema](#nestedblock--filter))
 - `host` (String) Parallels Desktop DevOps Host
 - `orchestrator` (String) Parallels Desktop DevOps Orchestrator
+- `wait_for_network_up` (Boolean) Wait for network up
 
 ### Read-Only
 

--- a/docs/resources/clone_vm.md
+++ b/docs/resources/clone_vm.md
@@ -189,6 +189,7 @@ Optional:
 
 Optional:
 
+- `always_run_on_update` (Boolean) Always run on update
 - `environment_variables` (Map of String) Environment variables that can be used in the DevOps service, please see documentation to see which variables are available
 - `inline` (List of String) Inline script
 - `retry` (Block, Optional) Retry settings (see [below for nested schema](#nestedblock--on_destroy_script--retry))
@@ -223,6 +224,7 @@ Optional:
 
 Optional:
 
+- `always_run_on_update` (Boolean) Always run on update
 - `environment_variables` (Map of String) Environment variables that can be used in the DevOps service, please see documentation to see which variables are available
 - `inline` (List of String) Inline script
 - `retry` (Block, Optional) Retry settings (see [below for nested schema](#nestedblock--post_processor_script--retry))

--- a/docs/resources/remote_vm.md
+++ b/docs/resources/remote_vm.md
@@ -197,6 +197,7 @@ Optional:
 
 Optional:
 
+- `always_run_on_update` (Boolean) Always run on update
 - `environment_variables` (Map of String) Environment variables that can be used in the DevOps service, please see documentation to see which variables are available
 - `inline` (List of String) Inline script
 - `retry` (Block, Optional) Retry settings (see [below for nested schema](#nestedblock--on_destroy_script--retry))
@@ -231,6 +232,7 @@ Optional:
 
 Optional:
 
+- `always_run_on_update` (Boolean) Always run on update
 - `environment_variables` (Map of String) Environment variables that can be used in the DevOps service, please see documentation to see which variables are available
 - `inline` (List of String) Inline script
 - `retry` (Block, Optional) Retry settings (see [below for nested schema](#nestedblock--post_processor_script--retry))

--- a/docs/resources/vagrant_box.md
+++ b/docs/resources/vagrant_box.md
@@ -190,6 +190,7 @@ Optional:
 
 Optional:
 
+- `always_run_on_update` (Boolean) Always run on update
 - `environment_variables` (Map of String) Environment variables that can be used in the DevOps service, please see documentation to see which variables are available
 - `inline` (List of String) Inline script
 - `retry` (Block, Optional) Retry settings (see [below for nested schema](#nestedblock--on_destroy_script--retry))
@@ -224,6 +225,7 @@ Optional:
 
 Optional:
 
+- `always_run_on_update` (Boolean) Always run on update
 - `environment_variables` (Map of String) Environment variables that can be used in the DevOps service, please see documentation to see which variables are available
 - `inline` (List of String) Inline script
 - `retry` (Block, Optional) Retry settings (see [below for nested schema](#nestedblock--post_processor_script--retry))

--- a/internal/common/post_processor_script.go
+++ b/internal/common/post_processor_script.go
@@ -75,7 +75,13 @@ func RunPostProcessorScript(ctx context.Context, hostConfig apiclient.HostConfig
 
 func PostProcessorHasChanges(ctx context.Context, planPostProcessorScript, statePostProcessorScript []*postprocessorscript.PostProcessorScript) bool {
 	for i, script := range planPostProcessorScript {
+		if script.AlwaysRunOnUpdate.ValueBool() {
+			return true
+		}
 		innerElements := script.Inline.Elements()
+		if len(innerElements) > 0 && len(statePostProcessorScript) == 0 {
+			return true
+		}
 		if len(innerElements) != len(statePostProcessorScript[i].Inline.Elements()) {
 			return true
 		}

--- a/internal/common/specs.go
+++ b/internal/common/specs.go
@@ -62,7 +62,7 @@ func SpecsBlockOnUpdate(ctx context.Context, hostConfig apiclient.HostConfig, vm
 		}
 
 		if hardwareInfo.TotalAvailable.LogicalCpuCount-int64(updateValueInt) <= 0 {
-			diagnostics.AddError("not enough cpus", "not enough cpus")
+			diagnostics.AddError("Not enough cpus", "You requested more cpus than available, the machine will need "+updateValue+" cpus and we have "+fmt.Sprintf("%v", hardwareInfo.TotalAvailable.LogicalCpuCount))
 			return diagnostics
 		}
 
@@ -88,7 +88,7 @@ func SpecsBlockOnUpdate(ctx context.Context, hostConfig apiclient.HostConfig, vm
 		}
 
 		if hardwareInfo.TotalAvailable.MemorySize-float64(updateValueInt) <= 0 {
-			diagnostics.AddError("not enough memory", "not enough memory")
+			diagnostics.AddError("Not enough memory", "You requested more memory than available, the machine will need "+updateValue+" memory and we have "+fmt.Sprintf("%v", hardwareInfo.TotalAvailable.MemorySize))
 			return diagnostics
 		}
 

--- a/internal/schemas/postprocessorscript/post_processor_script.go
+++ b/internal/schemas/postprocessorscript/post_processor_script.go
@@ -18,6 +18,7 @@ import (
 type PostProcessorScript struct {
 	Inline               types.List                `tfsdk:"inline"`
 	Retry                *PostProcessorScriptRetry `tfsdk:"retry"`
+	AlwaysRunOnUpdate    types.Bool                `tfsdk:"always_run_on_update"`
 	EnvironmentVariables map[string]types.String   `tfsdk:"environment_variables"`
 	Result               basetypes.ListValue       `tfsdk:"result"`
 }

--- a/internal/schemas/postprocessorscript/schemas.go
+++ b/internal/schemas/postprocessorscript/schemas.go
@@ -38,6 +38,10 @@ var (
 					Optional:            true,
 					ElementType:         types.StringType,
 				},
+				"always_run_on_update": schema.BoolAttribute{
+					MarkdownDescription: "Always run on update",
+					Optional:            true,
+				},
 				"result": schema.ListNestedAttribute{
 					MarkdownDescription: "Result of the script",
 					Description:         "Result of the script",

--- a/internal/telemetry/main.go
+++ b/internal/telemetry/main.go
@@ -14,6 +14,7 @@ var (
 	globalTelemetryService *TelemetryService
 	lock                          = &sync.Mutex{}
 	AMPLITUDE_API_KEY      string = ""
+	VERSION                       = ""
 )
 
 func New(context context.Context) *TelemetryService {

--- a/internal/telemetry/telemetry_item.go
+++ b/internal/telemetry/telemetry_item.go
@@ -32,6 +32,9 @@ func NewTelemetryItem(ctx context.Context, userId string, eventType TelemetryEve
 	// Adding default properties
 	item.Properties["os"] = runtime.GOOS
 	item.Properties["architecture"] = runtime.GOARCH
+	if VERSION != "" {
+		item.Properties["version"] = VERSION
+	}
 
 	hash := crypto.SHA256.New()
 	hash.Write([]byte(userId))

--- a/internal/virtualmachine/datasource.go
+++ b/internal/virtualmachine/datasource.go
@@ -3,6 +3,7 @@ package virtualmachine
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"terraform-provider-parallels-desktop/internal/apiclient"
 	"terraform-provider-parallels-desktop/internal/models"
@@ -48,11 +49,11 @@ func (d *VirtualMachinesDataSource) Metadata(_ context.Context, req datasource.M
 }
 
 func (d *VirtualMachinesDataSource) Schema(_ context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema = schemas.VirtualMachineDataSourceSchemaV1
+	resp.Schema = schemas.VirtualMachineDataSourceSchemaV2
 }
 
 func (d *VirtualMachinesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data data_models.VirtualMachinesDataSourceModelV1
+	var data data_models.VirtualMachinesDataSourceModelV2
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -82,31 +83,56 @@ func (d *VirtualMachinesDataSource) Read(ctx context.Context, req datasource.Rea
 		DisableTlsValidation: d.provider.DisableTlsValidation.ValueBool(),
 	}
 
-	vms, diag := apiclient.GetVms(ctx, hostConfig, data.Filter.FieldName.ValueString(), data.Filter.Value.ValueString())
-	if diag.HasError() {
-		diag.Append(diag...)
-		return
-	}
-
-	for _, machine := range vms {
-		stateMachine := data_models.VirtualMachineModelV1{
-			HostIP:             types.StringValue("-"),
-			ID:                 types.StringValue(machine.ID),
-			Name:               types.StringValue(machine.Name),
-			Description:        types.StringValue(machine.Description),
-			OSType:             types.StringValue(machine.OS),
-			State:              types.StringValue(machine.State),
-			Home:               types.StringValue(machine.Home),
-			ExternalIp:         types.StringValue(machine.HostExternalIpAddress),
-			InternalIp:         types.StringValue(machine.InternalIpAddress),
-			OrchestratorHostId: types.StringValue(machine.HostId),
+	retryAttempts := 10
+	for {
+		needsRefresh := false
+		data.Machines = make([]data_models.VirtualMachineModelV2, 0)
+		vms, diag := apiclient.GetVms(ctx, hostConfig, data.Filter.FieldName.ValueString(), data.Filter.Value.ValueString())
+		if diag.HasError() {
+			diag.Append(diag...)
+			return
 		}
 
-		data.Machines = append(data.Machines, stateMachine)
+		for _, machine := range vms {
+			stateMachine := data_models.VirtualMachineModelV2{
+				HostIP:             types.StringValue("-"),
+				ID:                 types.StringValue(machine.ID),
+				Name:               types.StringValue(machine.Name),
+				Description:        types.StringValue(machine.Description),
+				OSType:             types.StringValue(machine.OS),
+				State:              types.StringValue(machine.State),
+				Home:               types.StringValue(machine.Home),
+				ExternalIp:         types.StringValue(machine.HostExternalIpAddress),
+				InternalIp:         types.StringValue(machine.InternalIpAddress),
+				OrchestratorHostId: types.StringValue(machine.HostId),
+			}
+			if stateMachine.State.ValueString() == "running" && stateMachine.InternalIp.ValueString() == "" && data.WaitForNetworkUp.ValueBool() {
+				needsRefresh = true
+				time.Sleep(5 * time.Second) // wait for 5 seconds to give the network time to come up
+				break
+			}
+
+			if stateMachine.InternalIp.ValueString() == "" {
+				stateMachine.InternalIp = types.StringValue("-")
+			}
+
+			data.Machines = append(data.Machines, stateMachine)
+		}
+
+		if !needsRefresh {
+			break
+		}
+
+		if retryAttempts == 0 {
+			resp.Diagnostics.AddError("timeout waiting for network to be up", "timeout waiting for network to be up")
+			return
+		}
+
+		retryAttempts--
 	}
 
 	if data.Machines == nil {
-		data.Machines = make([]data_models.VirtualMachineModelV1, 0)
+		data.Machines = make([]data_models.VirtualMachineModelV2, 0)
 	}
 
 	diags := resp.State.Set(ctx, &data)

--- a/internal/virtualmachine/models/datasource_models_v2.go
+++ b/internal/virtualmachine/models/datasource_models_v2.go
@@ -1,0 +1,32 @@
+package models
+
+import (
+	"terraform-provider-parallels-desktop/internal/schemas/authenticator"
+	"terraform-provider-parallels-desktop/internal/schemas/filter"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// virtualMachinesDataSourceModel represents the data source schema for the virtual_machines data source.
+type VirtualMachinesDataSourceModelV2 struct {
+	Authenticator    *authenticator.Authentication `tfsdk:"authenticator"`
+	Host             types.String                  `tfsdk:"host"`
+	Orchestrator     types.String                  `tfsdk:"orchestrator"`
+	WaitForNetworkUp types.Bool                    `tfsdk:"wait_for_network_up"`
+	Filter           *filter.Filter                `tfsdk:"filter"`
+	Machines         []VirtualMachineModelV2       `tfsdk:"machines"`
+}
+
+// virtualMachineModel represents a virtual machine model with its properties.
+type VirtualMachineModelV2 struct {
+	HostIP             types.String `tfsdk:"host_ip"`              // The IP address of the host machine.
+	ID                 types.String `tfsdk:"id"`                   // The unique identifier of the virtual machine.
+	ExternalIp         types.String `tfsdk:"external_ip"`          // The external IP address of the virtual machine.
+	InternalIp         types.String `tfsdk:"internal_ip"`          // The internal IP address of the virtual machine.
+	OrchestratorHostId types.String `tfsdk:"orchestrator_host_id"` // The unique identifier of the orchestrator host.
+	Name               types.String `tfsdk:"name"`                 // The name of the virtual machine.
+	Description        types.String `tfsdk:"description"`          // The description of the virtual machine.
+	OSType             types.String `tfsdk:"os_type"`              // The type of the operating system installed on the virtual machine.
+	State              types.String `tfsdk:"state"`                // The state of the virtual machine.
+	Home               types.String `tfsdk:"home"`                 // The path to the virtual machine home directory.
+}

--- a/internal/virtualmachine/schemas/datasource_schema_v2.go
+++ b/internal/virtualmachine/schemas/datasource_schema_v2.go
@@ -1,0 +1,92 @@
+package schemas
+
+import (
+	"terraform-provider-parallels-desktop/internal/schemas/authenticator"
+	"terraform-provider-parallels-desktop/internal/schemas/filter"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var VirtualMachineDataSourceSchemaV2 = schema.Schema{
+	MarkdownDescription: "Virtual Machine Data Source",
+	Blocks: map[string]schema.Block{
+		authenticator.SchemaName: authenticator.SchemaBlock,
+		filter.SchemaName:        filter.SchemaBlock,
+	},
+	Attributes: map[string]schema.Attribute{
+		"host": schema.StringAttribute{
+			MarkdownDescription: "Parallels Desktop DevOps Host",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.AtLeastOneOf(path.Expressions{
+					path.MatchRoot("orchestrator"),
+					path.MatchRoot("host"),
+				}...),
+			},
+		},
+		"orchestrator": schema.StringAttribute{
+			MarkdownDescription: "Parallels Desktop DevOps Orchestrator",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.AtLeastOneOf(path.Expressions{
+					path.MatchRoot("orchestrator"),
+					path.MatchRoot("host"),
+				}...),
+			},
+		},
+		"wait_for_network_up": schema.BoolAttribute{
+			MarkdownDescription: "Wait for network up",
+			Optional:            true,
+		},
+		"machines": schema.ListNestedAttribute{
+			Computed: true,
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"host_ip": schema.StringAttribute{
+						MarkdownDescription: "The IP address of the host machine",
+						Computed:            true,
+					},
+					"id": schema.StringAttribute{
+						MarkdownDescription: "The unique identifier of the virtual machine",
+						Computed:            true,
+					},
+					"name": schema.StringAttribute{
+						MarkdownDescription: "The name of the virtual machine",
+						Computed:            true,
+					},
+					"description": schema.StringAttribute{
+						MarkdownDescription: "The description of the virtual machine",
+						Computed:            true,
+					},
+					"os_type": schema.StringAttribute{
+						MarkdownDescription: "The type of the operating system installed on the virtual machine",
+						Computed:            true,
+					},
+					"state": schema.StringAttribute{
+						MarkdownDescription: "The state of the virtual machine",
+						Computed:            true,
+					},
+					"home": schema.StringAttribute{
+						MarkdownDescription: "The path to the virtual machine home directory",
+						Computed:            true,
+					},
+					"orchestrator_host_id": schema.StringAttribute{
+						MarkdownDescription: "Orchestrator Host Id if the VM is running in an orchestrator",
+						Computed:            true,
+					},
+					"external_ip": schema.StringAttribute{
+						MarkdownDescription: "VM external IP address",
+						Computed:            true,
+					},
+					"internal_ip": schema.StringAttribute{
+						MarkdownDescription: "VM internal IP address",
+						Computed:            true,
+					},
+				},
+			},
+		},
+	},
+}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,8 @@ import (
 	"flag"
 	"log"
 
+	"terraform-provider-parallels-desktop/internal/telemetry"
+
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 
 	"terraform-provider-parallels-desktop/internal/provider"
@@ -23,17 +25,16 @@ import (
 // can be customized.
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
-var (
-	// these will be set by the goreleaser configuration
-	// to appropriate values for the compiled binary.
-	version string = "dev"
+// these will be set by the goreleaser configuration
+// to appropriate values for the compiled binary.
+var version string = "dev"
 
-	// goreleaser can pass other information to the main package, such as the specific commit
-	// https://goreleaser.com/cookbooks/using-main.version/
-)
+// goreleaser can pass other information to the main package, such as the specific commit
+// https://goreleaser.com/cookbooks/using-main.version/
 
 func main() {
 	var debug bool
+	telemetry.VERSION = version
 
 	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
@@ -49,7 +50,6 @@ func main() {
 	}
 
 	err := providerserver.Serve(context.Background(), provider.New(version), opts)
-
 	if err != nil {
 		log.Fatal(err.Error())
 	}


### PR DESCRIPTION
# Description

- Added the ability to set a post_processor_script to always run on update
- Fixed some issues where in some cases the update would but the vm in the wrong state
- Fixed an issue where some errors would bring a nil pointer
- Added an option to wait for network before querying to the datasource vm
- Added a retry mechanism to attempt to get the internal ip on create/update

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run linting on my code
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
